### PR TITLE
fix(book-installer): recognize equivalent feature layouts

### DIFF
--- a/skills/book-installer/references/feature-checklist-generator.md
+++ b/skills/book-installer/references/feature-checklist-generator.md
@@ -66,13 +66,19 @@ The script automatically:
   - `:white_check_mark:` for detected features
   - `:x:` for missing features
 
+Treat this output as a structural inventory, not proof that a feature works. The
+detector recognizes common MkDocs layouts and configuration patterns, but a
+project can implement the same capability through a custom hook or a different
+file structure. Verify consequential claims with the built site or a focused
+test before publishing the checklist.
+
 ### Step 4: Customize for Project
 
 Replace placeholders in the template:
 
 - `{BOOK_TITLE}` - From `site_name` in mkdocs.yml
-- `{CHAPTER_COUNT}` - Count of chapter directories
-- `{MICROSIM_COUNT}` - Count of sims directories
+- `{CHAPTER_COUNT}` - Count of chapter directories or flat numbered chapter files
+- `{MICROSIM_COUNT}` - Count of runnable sims directories containing `main.html`
 - `{GLOSSARY_TERM_COUNT}` - Count of terms in glossary.md
 - `{FAQ_COUNT}` - Count of questions in faq.md
 - `{QUIZ_COUNT}` - Count of quiz.md files
@@ -172,20 +178,20 @@ The Python script checks for features using these patterns:
 
 | Feature | Detection Method |
 |---------|-----------------|
-| Social media cards | `- social` in plugins |
+| Social media cards | `- social` in plugins or a configured social hook |
 | Edit page button | `edit_uri:` present |
 
 ### Advanced Features (from docs/)
 
 | Feature | Detection Method |
 |---------|-----------------|
-| MicroSims | `docs/sims/` directory with subdirectories |
+| MicroSims | `docs/sims/` directory with runnable subdirectories containing `main.html` |
 | MicroSim index | `docs/sims/index.md` exists |
 | Per-chapter quizzes | `quiz.md` files in chapter directories |
 | Course description | `docs/course-description.md` exists |
 | Learning graph CSV | `docs/learning-graph/*.csv` exists |
 | Learning graph JSON | `docs/learning-graph/*.json` exists |
-| Graph viewer | `docs/sims/graph-viewer/` exists |
+| Graph viewer | `docs/sims/graph-viewer/` or a `docs/learning-graph/explorer` implementation exists |
 | Concept taxonomy | `docs/learning-graph/concept-taxonomy.md` exists |
 | Book metrics | `docs/learning-graph/book-metrics.md` exists |
 | Chapter metrics | `docs/learning-graph/chapter-metrics.md` exists |
@@ -194,7 +200,7 @@ The Python script checks for features using these patterns:
 
 | Feature | Detection Method |
 |---------|-----------------|
-| Chapters | Count directories in `docs/chapters/` |
+| Chapters | Count directories or flat numbered Markdown files in `docs/chapters/` |
 | Pedagogical Agent (Mascot) | `docs/img/mascot/` directory exists with image files |
 | License page | `docs/license.md` exists |
 | Contact page | `docs/contact.md` exists |
@@ -232,9 +238,10 @@ After generation, you should:
 ### False Negatives
 
 If a feature shows as `:x:` but is actually implemented:
-- Check file paths match expected locations
+- Check whether the project uses an equivalent custom path or hook
 - Verify mkdocs.yml syntax is valid YAML
-- Ensure feature uses standard naming conventions
+- Improve the detector when the alternate implementation is reusable; do not
+  rearrange a mature book solely to satisfy a heuristic
 
 ### False Positives
 

--- a/skills/book-installer/scripts/detect_features.py
+++ b/skills/book-installer/scripts/detect_features.py
@@ -81,6 +81,12 @@ def get_extra_css(config: dict) -> list:
     return config.get('extra_css', []) or []
 
 
+def get_hooks(config: dict) -> list:
+    """Extract MkDocs hook paths from config."""
+    hooks = config.get('hooks', []) or []
+    return [str(hook) for hook in hooks]
+
+
 def count_files(directory: Path, pattern: str) -> int:
     """Count files matching a glob pattern."""
     if not directory.exists():
@@ -93,6 +99,64 @@ def count_directories(directory: Path) -> int:
     if not directory.exists():
         return 0
     return len([d for d in directory.iterdir() if d.is_dir()])
+
+
+def count_chapters(chapters_path: Path) -> int:
+    """Count directory-based or flat-file chapters without counting indexes."""
+    if not chapters_path.exists():
+        return 0
+
+    chapter_directories = [
+        path for path in chapters_path.iterdir()
+        if path.is_dir() and not path.name.startswith('.')
+    ]
+    if chapter_directories:
+        return len(chapter_directories)
+
+    numbered_chapters = [
+        path for path in chapters_path.glob("*.md")
+        if re.match(r'^\d+[._-].+\.md$', path.name)
+    ]
+    if numbered_chapters:
+        return len(numbered_chapters)
+
+    return len([
+        path for path in chapters_path.glob("*.md")
+        if path.name.lower() not in {"index.md", "readme.md"}
+    ])
+
+
+def count_microsims(sims_path: Path) -> int:
+    """Count runnable MicroSim directories, excluding shared utilities."""
+    if not sims_path.exists():
+        return 0
+    return len([
+        path for path in sims_path.iterdir()
+        if path.is_dir() and (path / "main.html").is_file()
+    ])
+
+
+def has_social_media_cards(project_path: Path, plugins: list, hooks: list) -> bool:
+    """Detect MkDocs social cards supplied by a plugin or a social hook."""
+    if "social" in plugins:
+        return True
+
+    return any(
+        "social" in Path(hook).name.lower() and (project_path / hook).is_file()
+        for hook in hooks
+    )
+
+
+def has_graph_viewer(docs_path: Path) -> bool:
+    """Detect the legacy MicroSim viewer or a learning-graph explorer."""
+    if (docs_path / "sims" / "graph-viewer").is_dir():
+        return True
+
+    graph_path = docs_path / "learning-graph"
+    return (
+        (graph_path / "explorer.md").is_file()
+        and any((graph_path / f"explorer.{suffix}").is_file() for suffix in ("html", "js"))
+    )
 
 
 def count_glossary_terms(glossary_path: Path) -> int:
@@ -159,6 +223,7 @@ def detect_features(project_path: Path) -> dict:
     plugins = get_plugins(config)
     extra_js = get_extra_javascript(config)
     extra_css = get_extra_css(config)
+    hooks = get_hooks(config)
     theme = config.get('theme', {})
     extra = config.get('extra', {})
 
@@ -177,8 +242,8 @@ def detect_features(project_path: Path) -> dict:
         "site_author": config.get('site_author', ''),
 
         # Counts
-        "chapter_count": count_directories(docs_path / "chapters"),
-        "microsim_count": count_directories(docs_path / "sims"),
+        "chapter_count": count_chapters(docs_path / "chapters"),
+        "microsim_count": count_microsims(docs_path / "sims"),
         "glossary_term_count": count_glossary_terms(docs_path / "glossary.md"),
         "faq_question_count": count_faq_questions(docs_path / "faq.md"),
         "quiz_file_count": count_files(docs_path, "**/quiz.md"),
@@ -244,13 +309,13 @@ def detect_features(project_path: Path) -> dict:
 
         # Publishing Features
         "publishing": {
-            "social_media_cards": "social" in plugins,
+            "social_media_cards": has_social_media_cards(project_path, plugins, hooks),
             "edit_page_button": bool(config.get('edit_uri')) or "content.action.edit" in features,
         },
 
         # Advanced Features - Interactive Learning
         "interactive_learning": {
-            "microsims": dir_exists(docs_path, "sims") and count_directories(docs_path / "sims") > 0,
+            "microsims": count_microsims(docs_path / "sims") > 0,
             "microsim_index": file_exists(docs_path / "sims", "index.md"),
             "per_chapter_quizzes": count_files(docs_path, "**/quiz.md") > 0,
         },
@@ -260,7 +325,7 @@ def detect_features(project_path: Path) -> dict:
             "course_description": file_exists(docs_path, "course-description.md"),
             "learning_graph_csv": len(list((docs_path / "learning-graph").glob("*.csv")) if dir_exists(docs_path, "learning-graph") else []) > 0,
             "learning_graph_json": len(list((docs_path / "learning-graph").glob("*.json")) if dir_exists(docs_path, "learning-graph") else []) > 0,
-            "graph_viewer": dir_exists(docs_path / "sims", "graph-viewer"),
+            "graph_viewer": has_graph_viewer(docs_path),
             "concept_taxonomy": file_exists(docs_path / "learning-graph", "concept-taxonomy.md"),
             "concept_list": file_exists(docs_path / "learning-graph", "concept-list.md"),
             "quality_metrics": file_exists(docs_path / "learning-graph", "quality-metrics.md"),
@@ -275,7 +340,7 @@ def detect_features(project_path: Path) -> dict:
 
         # Content Generation
         "content_generation": {
-            "chapters": count_directories(docs_path / "chapters") > 0,
+            "chapters": count_chapters(docs_path / "chapters") > 0,
             "pedagogical_agent": dir_exists(docs_path / "img", "mascot"),
             "prompts_collection": dir_exists(docs_path, "prompts"),
         },

--- a/skills/book-installer/tests/test_detect_features.py
+++ b/skills/book-installer/tests/test_detect_features.py
@@ -1,0 +1,63 @@
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT_PATH = Path(__file__).parents[1] / "scripts" / "detect_features.py"
+SPEC = importlib.util.spec_from_file_location("detect_features", SCRIPT_PATH)
+detect_features = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(detect_features)
+
+
+class FeatureDetectionTests(unittest.TestCase):
+    def test_counts_flat_numbered_chapters_without_index(self):
+        with tempfile.TemporaryDirectory() as directory:
+            chapters = Path(directory)
+            (chapters / "index.md").write_text("# Chapters\n", encoding="utf-8")
+            (chapters / "01-introduction.md").write_text("# One\n", encoding="utf-8")
+            (chapters / "02-method.md").write_text("# Two\n", encoding="utf-8")
+
+            self.assertEqual(detect_features.count_chapters(chapters), 2)
+
+    def test_prefers_directory_chapters_when_present(self):
+        with tempfile.TemporaryDirectory() as directory:
+            chapters = Path(directory)
+            (chapters / "chapter-1").mkdir()
+            (chapters / "chapter-2").mkdir()
+            (chapters / "index.md").write_text("# Chapters\n", encoding="utf-8")
+
+            self.assertEqual(detect_features.count_chapters(chapters), 2)
+
+    def test_counts_only_runnable_microsims(self):
+        with tempfile.TemporaryDirectory() as directory:
+            sims = Path(directory)
+            (sims / "working-sim").mkdir()
+            (sims / "working-sim" / "main.html").write_text("<main></main>", encoding="utf-8")
+            (sims / "shared").mkdir()
+            (sims / "shared" / "microsim.js").write_text("", encoding="utf-8")
+
+            self.assertEqual(detect_features.count_microsims(sims), 1)
+
+    def test_detects_social_hook_and_learning_graph_explorer(self):
+        with tempfile.TemporaryDirectory() as directory:
+            project = Path(directory)
+            docs = project / "docs"
+            graph = docs / "learning-graph"
+            hook = project / "plugins" / "social_override.py"
+            graph.mkdir(parents=True)
+            hook.parent.mkdir()
+            hook.write_text("", encoding="utf-8")
+            (graph / "explorer.md").write_text("# Explorer\n", encoding="utf-8")
+            (graph / "explorer.js").write_text("", encoding="utf-8")
+
+            self.assertTrue(
+                detect_features.has_social_media_cards(
+                    project, [], ["plugins/social_override.py"]
+                )
+            )
+            self.assertTrue(detect_features.has_graph_viewer(docs))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

The feature checklist now recognizes mature intelligent textbooks that use flat numbered chapters, runnable MicroSims alongside shared utility folders, hook-based social cards, and a learning-graph explorer outside the legacy MicroSim path. Previously, those valid layouts produced four misleading results in *X Marketing with actions.json*: zero chapters, fifteen instead of fourteen MicroSims, and missing social-card and graph-viewer capabilities.

The detector remains a structural inventory rather than proof that a feature works; the guide now makes that boundary explicit. Focused fixtures cover both chapter layouts, runnable-MicroSim counting, the social hook, and the alternate graph explorer.

## Validation

- `python3 -m unittest discover -s skills/book-installer/tests -v` (4 tests pass)
- Live detector run against `x-marketing-frontier-textbook` reports 12 chapters, 14 runnable MicroSims, social cards present, and graph viewer present.
