### PR TITLE
reference-generator: add the book-level references page (Step 8)

### DIFF
--- a/skills/reference-generator/SKILL.md
+++ b/skills/reference-generator/SKILL.md
@@ -1,13 +1,23 @@
 ---
 name: reference-generator
-description: Generates 10 curated academic references per chapter, prioritizing Wikipedia plus credited textbook authors known for innovative explanations, with relevance descriptions, stored in chapter references.md files. Use when an intelligent textbook chapter needs citations.
+description: Generates 10 curated academic references per chapter, prioritizing Wikipedia plus credited textbook authors known for innovative explanations, with relevance descriptions, stored in chapter references.md files, then aggregates them into a book-level docs/references.md. Use when an intelligent textbook chapter needs citations.
 metadata:
-  ibook.version: "1.0"
+  ibook.version: "1.1"
 ---
 
 # Reference Generator
 
-**Version:** 1.0
+**Version:** 1.1
+
+### Changelog
+
+- **v1.1** — Adds Step 8, the book-level `docs/references.md`. The skill
+  previously stopped at per-chapter files, which leaves a reader with no way to
+  see what the whole book rests on, and no way to find a source again without
+  remembering which chapter it was in. Several books in this workspace carry a
+  hand-written `docs/references.md` that drifts out of step with the chapters as
+  soon as either changes; generating it from the chapter files means it cannot.
+  Adds `src/book-references/build-book-references.py`.
 
 ## Overview
 
@@ -176,6 +186,51 @@ edits, `Content:` label for the chapter page) in
     - Quiz: chapters/01-chapter-folder/quiz.md
     - Annotated References: chapters/01-chapter-folder/references.md
 ```
+
+### Step 8: Generate the Book-Level References Page
+
+The per-chapter files answer "what should I read next about *this*". They do not
+answer "what does this book rest on", and they make a source impossible to find
+again unless the reader remembers which chapter cited it. A source cited by six
+chapters looks like six unrelated entries.
+
+Generate one aggregated page from the chapter files:
+
+```bash
+python3 "$BK_HOME/src/book-references/build-book-references.py" .
+```
+
+It deduplicates by URL, keeps the fullest description any chapter wrote for a
+source, and lists the chapters citing each one. Options: `--output`, `--title`,
+`--min-shared`, and `--dry-run`.
+
+**Generate it, never hand-write it.** A hand-written bibliography drifts the
+moment a chapter's references change, and nothing warns you. Re-run this after
+any change to chapter references, and after adding or removing a chapter.
+
+Then add it to `mkdocs.yml`, following the nav-editing rules in
+`$BK_HOME/skills/book-installer/references/mkdocs-nav-editing.md`:
+
+```yaml
+  - References: references.md
+```
+
+**Check the two things the script reports.** It names any chapter carrying fewer
+than five references, which usually means Step 3 was skipped or a chapter was
+added later. And compare the distinct-source count against the total citation
+count: if they are nearly equal, no source is doing work across chapters, which
+in a book with a real concept graph is a sign the chapters were researched in
+isolation rather than as one book.
+
+#### Say how the sources were handled, not only what they were
+
+For any book where a reader might act on a claim — health, safety, legal,
+financial — a list of sources is only half of what they need. Add a short
+section above the list saying how citations were handled: what evidence grading
+was used, whether citations were verified against primary sources or accepted on
+the author's confidence, what remains unchecked, and what any automated link
+checking does and does not prove. Fetching a URL tells you it resolves; it does
+not tell you the page still says what it said.
 
 ## Reference Quality Guidelines
 

--- a/src/book-references/README.md
+++ b/src/book-references/README.md
@@ -1,0 +1,61 @@
+# Book-level references
+
+`build-book-references.py` aggregates the per-chapter `references.md` files that
+the `reference-generator` skill produces into a single `docs/references.md`.
+
+## Why
+
+The skill generates `docs/chapters/NN-name/references.md` for every chapter and
+stops there. That answers "what should I read next about *this*" and leaves two
+things unanswered: what the whole book rests on, and where a reader can find a
+source again without remembering which chapter cited it. A source cited by six
+chapters appears as six unrelated entries and looks like six sources.
+
+Several books in this workspace carry a hand-written `docs/references.md`. It
+drifts out of step with the chapters the moment either changes, and nothing
+warns anyone. Generating it means it cannot.
+
+## Usage
+
+```bash
+python3 "$BK_HOME/src/book-references/build-book-references.py" .
+
+# preview without writing
+python3 "$BK_HOME/src/book-references/build-book-references.py" . --dry-run
+
+# elsewhere, or with a different heading
+python3 "$BK_HOME/src/book-references/build-book-references.py" . \
+    --output docs/bibliography.md --title Bibliography
+```
+
+Then add it to `mkdocs.yml`:
+
+```yaml
+  - References: references.md
+```
+
+## What it does
+
+- Parses every numbered entry in `docs/chapters/*/references.md`, joining entries
+  that wrap across lines.
+- Deduplicates by URL, so a source cited by several chapters is one entry that
+  names them all. Sources without a URL fall back to their title.
+- Keeps the fullest description and publisher any chapter wrote for a source.
+- Emits a "used by more than one chapter" section ahead of the A-to-Z list.
+
+## Two numbers worth reading
+
+It reports **any chapter with fewer than five references**, which usually means
+the per-chapter step was skipped or a chapter was added afterwards.
+
+It also reports distinct sources against total citations. If those are nearly
+equal, no source is doing work across chapters — in a book built on a concept
+graph that usually means the chapters were researched in isolation rather than
+as one book. On the books tested: 90 sources from 150 citations, and 257 from
+320, both healthy; one book at 160 from 170, which is the pattern to look at.
+
+## Exit behaviour
+
+Exits non-zero with an explanation if there is no `docs/` directory, or if no
+per-chapter reference files exist yet — in which case run `reference-generator`
+first.

--- a/src/book-references/build-book-references.py
+++ b/src/book-references/build-book-references.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Build a book-level docs/references.md from the per-chapter reference files.
+
+The reference-generator skill produces `docs/chapters/NN-name/references.md` for
+every chapter and stops there. A reader who wants to know what the whole book
+rests on, or who wants to find a source again without remembering which chapter
+it was in, has nowhere to go. Several books in this workspace carry a
+hand-written `docs/references.md` that drifts out of step with the chapters as
+soon as either changes.
+
+This aggregates the chapter files instead: one entry per distinct source,
+deduplicated by URL, listing the chapters that cite it. Regenerate it whenever
+chapter references change and it cannot drift.
+
+Usage:
+    python3 build-book-references.py /path/to/project
+    python3 build-book-references.py /path/to/project --title "References"
+    python3 build-book-references.py /path/to/project --dry-run
+"""
+import argparse
+import glob
+import os
+import re
+import sys
+from collections import defaultdict
+
+ENTRY = re.compile(r"^\s*\d+\.\s+(.*)$")
+LINK = re.compile(r"\[([^\]]+)\]\((https?://[^)\s]+)\)")
+CHAPTER_DIR = re.compile(r"^(\d+)[-_](.+)$")
+
+
+def chapter_title(path):
+    """Prefer the chapter's H1, falling back to its directory name."""
+    index = os.path.join(os.path.dirname(path), "index.md")
+    if os.path.exists(index):
+        for line in open(index, encoding="utf-8"):
+            if line.startswith("# "):
+                return line[2:].strip()
+    name = os.path.basename(os.path.dirname(path))
+    m = CHAPTER_DIR.match(name)
+    return (m.group(2) if m else name).replace("-", " ").title()
+
+
+def parse_entries(path):
+    """Yield each numbered reference, joining the lines it wraps across."""
+    buf = None
+    for line in open(path, encoding="utf-8").read().splitlines() + [""]:
+        m = ENTRY.match(line)
+        if m:
+            if buf:
+                yield buf
+            buf = m.group(1).strip()
+        elif buf is not None and line.strip() and not line.lstrip().startswith("#"):
+            buf += " " + line.strip()
+        elif buf:
+            yield buf
+            buf = None
+
+
+def collect(docs_dir):
+    refs, per_chapter, chapters = {}, defaultdict(int), {}
+    pattern = os.path.join(docs_dir, "chapters", "*", "references.md")
+    for path in sorted(glob.glob(pattern)):
+        dirname = os.path.basename(os.path.dirname(path))
+        m = CHAPTER_DIR.match(dirname)
+        if not m:
+            continue
+        n = int(m.group(1))
+        chapters[n] = {"dir": dirname, "title": chapter_title(path)}
+        for text in parse_entries(path):
+            link = LINK.search(text)
+            url = link.group(2) if link else None
+            title = link.group(1) if link else text.split(" - ")[0].strip(" *_")
+            if not title:
+                continue
+            # a source is the same source wherever it is cited, so key on the URL
+            key = url or title.lower()
+            parts = [p.strip() for p in LINK.sub(r"\1", text).split(" - ")]
+            publisher = parts[1] if len(parts) > 1 else ""
+            blurb = " - ".join(parts[2:]) if len(parts) > 2 else ""
+            entry = refs.setdefault(key, {"title": title, "url": url,
+                                          "publisher": publisher, "blurb": blurb,
+                                          "chapters": set()})
+            entry["chapters"].add(n)
+            # keep the fullest description any chapter wrote for it
+            if len(blurb) > len(entry["blurb"]):
+                entry["blurb"] = blurb
+            if len(publisher) > len(entry["publisher"]):
+                entry["publisher"] = publisher
+            per_chapter[n] += 1
+    return refs, per_chapter, chapters
+
+
+def render(refs, per_chapter, chapters, title, min_shared):
+    def cite(r):
+        head = f"[{r['title']}]({r['url']})" if r["url"] else f"**{r['title']}**"
+        pub = f" - {r['publisher']}" if r["publisher"] else ""
+        blurb = f" - {r['blurb']}" if r["blurb"] else ""
+        cited = ", ".join(
+            f"[{n}](chapters/{chapters[n]['dir']}/index.md)"
+            for n in sorted(r["chapters"]) if n in chapters)
+        plural = "s" if len(r["chapters"]) > 1 else ""
+        return (f"- {head}{pub}{blurb}  \n"
+                f"  <small>Cited in chapter{plural} {cited}</small>")
+
+    total_citations = sum(per_chapter.values())
+    shared = sorted((r for r in refs.values() if len(r["chapters"]) >= min_shared),
+                    key=lambda r: (-len(r["chapters"]), r["title"].lower()))
+    alpha = sorted(refs.values(), key=lambda r: r["title"].lower())
+
+    out = [f"""---
+title: {title}
+description: Every source this book cites, and the chapters that cite it.
+---
+
+# {title}
+
+**{len(refs)} distinct sources** across **{total_citations} citations** in
+**{len(chapters)} chapters**.
+
+Generated from the per-chapter reference lists, so it cannot drift out of step
+with them. Each chapter also carries its own list, which is the better place to
+start if you have a chapter in mind.
+"""]
+
+    if shared:
+        out.append(f"\n## Sources used by more than one chapter\n\n"
+                   f"The {len(shared)} the book leans on most.\n")
+        out.extend(cite(r) for r in shared)
+
+    out.append("\n## Every source, A to Z\n")
+    out.extend(cite(r) for r in alpha)
+    return "\n".join(out) + "\n"
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("project", nargs="?", default=".",
+                    help="project root containing docs/ (default: .)")
+    ap.add_argument("--output", default=None,
+                    help="output path (default: <project>/docs/references.md)")
+    ap.add_argument("--title", default="References", help="page H1 and title")
+    ap.add_argument("--min-shared", type=int, default=2,
+                    help="cite count for the 'used by more than one chapter' "
+                         "section (default: 2)")
+    ap.add_argument("--dry-run", action="store_true",
+                    help="report what would be written without writing it")
+    args = ap.parse_args()
+
+    docs = os.path.join(args.project, "docs")
+    if not os.path.isdir(docs):
+        sys.exit(f"No docs/ directory under {args.project}")
+
+    refs, per_chapter, chapters = collect(docs)
+    if not refs:
+        sys.exit("No chapter reference files found at "
+                 "docs/chapters/*/references.md. Run reference-generator first.")
+
+    body = render(refs, per_chapter, chapters, args.title, args.min_shared)
+    out = args.output or os.path.join(docs, "references.md")
+
+    print(f"{len(refs)} distinct sources from {sum(per_chapter.values())} citations "
+          f"across {len(chapters)} chapters")
+    thin = [n for n, c in sorted(per_chapter.items()) if c < 5]
+    if thin:
+        print(f"  chapters with fewer than 5 references: "
+              f"{', '.join(str(n) for n in thin)}")
+    if args.dry_run:
+        print(f"  (dry run — would write {out})")
+        return 0
+
+    os.makedirs(os.path.dirname(out), exist_ok=True)
+    with open(out, "w", encoding="utf-8") as fh:
+        fh.write(body)
+    print(f"Wrote {out}")
+    print("Add it to mkdocs.yml nav as:  - References: references.md")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## The gap

`reference-generator` produces `docs/chapters/NN-name/references.md` for every
chapter and stops there. That answers *what should I read next about this* and
leaves two things unanswered:

- What does the whole book rest on?
- How does a reader find a source again without remembering which chapter cited it?

A source cited by six chapters currently appears as six unrelated entries and
looks like six sources.

Several books carry a hand-written `docs/references.md` instead — this repo's own
book does. A hand-written one drifts out of step with the chapters as soon as
either changes, and nothing warns anyone that it has.

## What this adds

**`src/book-references/build-book-references.py`** aggregates the per-chapter
files into one `docs/references.md`. Deduplicates by URL, keeps the fullest
description any chapter wrote for a source, and lists the chapters citing each
one.

```bash
python3 "$BK_HOME/src/book-references/build-book-references.py" .
```

**Step 8 in `reference-generator/SKILL.md`**, plus a version bump to 1.1.

## Two numbers it reports rather than just writing a file

- **Chapters with fewer than five references** — usually means the per-chapter
  step was skipped, or a chapter was added afterwards.
- **Distinct sources against total citations.** If those are nearly equal, no
  source is doing work across chapters. In a book built on a concept graph that
  usually means the chapters were researched in isolation rather than as one
  book.

## Step 8 also asks for something beyond the list

For any book where a reader might act on a claim, a list of sources is half of
what they need. The new step asks authors to say *how* citations were handled:
what evidence grading was used, what was verified against a primary source and
what was accepted on the author's confidence, what remains unchecked, and what
automated link checking does and does not prove.

Fetching a URL tells you it resolves. It does not tell you the page still says
what it said.

## Testing

Run against four projects:

| Book | Result |
|---|---|
| A 15-chapter book | 90 distinct sources from 150 citations |
| A 32-chapter book | 257 from 320 |
| A 17-chapter book | 160 from 170 — the near-1:1 case the new guidance flags |
| This repo's own book | Fails cleanly: no per-chapter reference files exist |

That last one is the gap in miniature. This book's `docs/references.md` is
hand-written and cannot be regenerated from anything.

## Notes

- No existing behaviour changes. Steps 1–7 are untouched; Step 8 is additive.
- Follows the `src/<tool>/` layout used by `src/book-metrics/`, with a README.
- Exits non-zero with an explanation when there is no `docs/` directory or no
  per-chapter reference files yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)